### PR TITLE
Changed IP address from 127.0.0.1 to 0.0.0.0 for UDP socket

### DIFF
--- a/src/tasks/task003.rs
+++ b/src/tasks/task003.rs
@@ -42,7 +42,7 @@ pub fn start(client: &mut Client, buf: &[u8]) -> Result<bool, Box<dyn Error>> {
 
 fn transmit_loop(total_length: u32, character: u8, bytevector: &[u8]) ->  Result<(), AdNetError> {
     // TODO: error processing
-    let socket = UdpSocket::bind("127.0.0.1:20000").unwrap();
+    let socket = UdpSocket::bind("0.0.0.0:20000").unwrap();
     let mut cumulative = 0;
     let mut received: usize = 0;
 


### PR DESCRIPTION
Found that changing the IP address to 0.0.0.0 stopped adnet-agent on RH1 from responding with "Port Unreachable".