### PR TITLE
Bug: Fix cumulative acks for out of order packets in UDP task

### DIFF
--- a/src/tasks/udp.rs
+++ b/src/tasks/udp.rs
@@ -88,13 +88,13 @@ fn transmit_loop(total_length: u32, character: u8, bytevector: &[u8]) ->  Result
             received += len as usize;
             cumulative += 1;
 
-            // check if out-of-order sequence set can be cleaned up with this datagram
-            if let Some(ofolen) = ofo_set.get(&cumulative) {
-                received += *ofolen as usize;
-                ofo_set.remove(&cumulative);
+            // Clear all consecutive out-of-order packets from the buffer in a loop since there can be more than one
+            while let Some(&ofolen) = ofo_set.get(&(cumulative + 1)) {
+                received += ofolen as usize;
+                ofo_set.remove(&(cumulative + 1));
                 cumulative += 1;
             }
-            send_ack(&socket, address, sequence, bytevector[received % 97]);
+            send_ack(&socket, address, cumulative, bytevector[received % 97]);
         } else {
             if sequence > cumulative {
                 ofo_set.insert(sequence, len);


### PR DESCRIPTION
There seems to be couple of bugs in how cumulative acknowledgements are handled:

1. In original code `ofo_set.get(&cumulative)` will check if the currently arrived packet is the one which we just recieved, not the next one. At least as I read the code `cumulative` seems to store latest arrived package, not next expected one - se we need to look up for `cumulative+1` in order to check if any out of order packets can be cleared.
2. There is no loop in out-of-order package check, but we can have a whole interval to clear, not a single package
3. In the original code, we send out an ack for current `sequence`, but we should instead send out ack for the package number of the maximum cleared out-of-order packet, which is `cumulative` after incrementing it. 

I might have misunderstood what some parts of the code are intended to do, but based on my attempts of completing the UDP assignemnt it doesn't look like the out-of-order packets are cleared properly. 